### PR TITLE
Add "filenames" and "exclude" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ copyfileartifacts:
 ```
 
 d
-`exclude`-d files take precedence over other matching, meaning exclude will trump other matches by either `extensions` or `filenames`.
+`exclude`-d files take precedence over other matching, meaning exclude will
+trump other matches by either `extensions` or `filenames`.
 
 ### Renaming files
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ copyfileartifacts:
   extensions: .cue .log
 ```
 
+Or copy files by filename:
+
+```yaml
+copyfileartifacts:
+  filenames: song.log
+```
+
 Or copy all non-music files (it does this by default):
 
 ```yaml
@@ -57,7 +64,14 @@ copyfileartifacts:
   extensions: .*
 ```
 
-It can also print what got left:
+It can also exclude files by name:
+
+```yaml
+copyfileartifacts:
+  exclude: song_lyrics.nfo
+```
+
+And print what got left:
 
 ```yaml
 copyfileartifacts:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ copyfileartifacts:
   print_ignored: yes
 ```
 
+d
+`exclude`-d files take precedence over other matching, meaning exclude will trump other matches by either `extensions` or `filenames`.
+
 ### Renaming files
 
 Renaming works in much the same way as beets [Path Formats](http://beets.readthedocs.org/en/stable/reference/pathformat.html)

--- a/beetsplug/copyfileartifacts.py
+++ b/beetsplug/copyfileartifacts.py
@@ -159,14 +159,14 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
                 ignored_files.append(source_file)
                 continue
 
-            # Skip if filename is expicitly in `exclude`
+            # Skip if filename is explicitly in `exclude`
             if filename.decode("utf8") in self.exclude:
                 ignored_files.append(source_file)
                 continue
 
             # Skip:
             # - extensions not allowed in `extensions`
-            # - filenames not expicitly in `filenames`
+            # - filenames not explicitly in `filenames`
             file_ext = os.path.splitext(filename)[1]
             if (
                 ".*" not in self.extensions

--- a/beetsplug/copyfileartifacts.py
+++ b/beetsplug/copyfileartifacts.py
@@ -15,12 +15,21 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
     def __init__(self):
         super(CopyFileArtifactsPlugin, self).__init__()
 
-        self.config.add({"extensions": ".*", "print_ignored": False})
+        self.config.add(
+            {
+                "extensions": ".*",
+                "filenames": "",
+                "exclude": "",
+                "print_ignored": False,
+            }
+        )
 
         self._process_queue = []
         self._dirs_seen = []
 
         self.extensions = self.config["extensions"].as_str_seq()
+        self.filenames = self.config["filenames"].as_str_seq()
+        self.exclude = self.config["exclude"].as_str_seq()
         self.print_ignored = self.config["print_ignored"].get()
 
         self.path_formats = [
@@ -150,11 +159,19 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
                 ignored_files.append(source_file)
                 continue
 
-            # Skip extensions not handled by plugin
+            # Skip if filename is expicitly in `exclude`
+            if filename.decode("utf8") in self.exclude:
+                ignored_files.append(source_file)
+                continue
+
+            # Skip:
+            # - extensions not allowed in `extensions`
+            # - filenames not expicitly in `filenames`
             file_ext = os.path.splitext(filename)[1]
             if (
                 ".*" not in self.extensions
                 and file_ext.decode("utf8") not in self.extensions
+                and filename.decode("utf8") not in self.filenames
             ):
                 ignored_files.append(source_file)
                 continue
@@ -210,4 +227,5 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
         beets.util.move(source_file, dest_file)
 
         dir_path = os.path.split(source_file)[0]
+
         beets.util.prune_dirs(dir_path, clutter=config["clutter"].as_str_seq())

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -114,10 +114,7 @@ class DummyOut(object):
         self.buf.append(s)
 
     def get(self):
-        if six.PY2:
-            return b"".join(self.buf)
-        else:
-            return "".join(self.buf)
+        return "".join(self.buf)
 
     def flush(self):
         self.clear()
@@ -135,10 +132,7 @@ class DummyIn(object):
         self.out = out
 
     def add(self, s):
-        if six.PY2:
-            self.buf.append(s + b"\n")
-        else:
-            self.buf.append(s + "\n")
+        self.buf.append(s + "\n")
 
     def readline(self):
         if not self.buf:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from enum import Enum
 
 import mediafile
-import six
 from beets import config, importer, library, plugins, util
 
 # Make sure the development versions of the plugins are used
@@ -29,7 +28,7 @@ class LogCapture(logging.Handler):
         self.messages = []
 
     def emit(self, record):
-        self.messages.append(six.text_type(record.msg))
+        self.messages.append(str(record.msg))
 
 
 @contextmanager
@@ -119,7 +118,9 @@ class CopyFileArtifactsTestCase(_common.TestCase):
           the_album/
             track_1.mp3
             artifact.file
+            artifact2.file
             artifact.file2
+            artifact.file3
         """
         self._set_import_dir()
 
@@ -128,7 +129,9 @@ class CopyFileArtifactsTestCase(_common.TestCase):
 
         # Create artifact
         open(os.path.join(album_path, b"artifact.file"), "a").close()
+        open(os.path.join(album_path, b"artifact2.file"), "a").close()
         open(os.path.join(album_path, b"artifact.file2"), "a").close()
+        open(os.path.join(album_path, b"artifact.file3"), "a").close()
 
         medium = self._create_medium(
             os.path.join(album_path, b"track_1.mp3"), b"full.mp3"

--- a/tests/test_flatdirectory.py
+++ b/tests/test_flatdirectory.py
@@ -24,22 +24,109 @@ class CopyFileArtifactsFromFlatDirectoryTest(CopyFileArtifactsTestCase):
 
         self._run_importer()
 
+        self.assert_number_of_files_in_dir(
+            3, self.lib_dir, b"Tag Artist", b"Tag Album"
+        )
+
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
+
         self.assert_not_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"artifact.file2"
+        )
+        self.assert_not_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"artifact.file3"
+        )
+
+    def test_exclude_artifacts_matching_configured_exclude(self):
+        config["copyfileartifacts"]["extensions"] = ".file"
+        config["copyfileartifacts"]["exclude"] = "artifact2.file"
+
+        self._run_importer()
+
+        self.assert_number_of_files_in_dir(
+            2, self.lib_dir, b"Tag Artist", b"Tag Album"
+        )
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+
+        self.assert_not_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"artifact2.file"
+        )
+        self.assert_not_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"artifact.file2"
+        )
+        self.assert_not_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"artifact.file3"
+        )
+
+    def test_only_copy_artifacts_matching_configured_filename(self):
+        config["copyfileartifacts"]["extensions"] = ""
+        config["copyfileartifacts"]["filenames"] = "artifact.file"
+
+        self._run_importer()
+
+        self.assert_number_of_files_in_dir(
+            2, self.lib_dir, b"Tag Artist", b"Tag Album"
+        )
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+
+        self.assert_not_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"artifact2.file"
+        )
+        self.assert_not_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"artifact.file2"
+        )
+        self.assert_not_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"artifact.file3"
+        )
+
+    def test_only_copy_artifacts_matching_configured_extension_and_filename(
+        self,
+    ):
+        config["copyfileartifacts"]["extensions"] = ".file"
+        config["copyfileartifacts"]["filenames"] = "artifact.file2"
+
+        self._run_importer()
+
+        self.assert_number_of_files_in_dir(
+            4, self.lib_dir, b"Tag Artist", b"Tag Album"
+        )
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file2")
+
+        self.assert_number_of_files_in_dir(5, self.import_dir, b"the_album")
+
+        self.assert_not_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"artifact.file3"
         )
 
     def test_copy_all_artifacts_by_default(self):
         self._run_importer()
 
+        self.assert_number_of_files_in_dir(
+            5, self.lib_dir, b"Tag Artist", b"Tag Album"
+        )
+
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file2")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file3")
 
     def test_copy_artifacts(self):
         self._run_importer()
 
+        self.assert_number_of_files_in_dir(
+            5, self.lib_dir, b"Tag Artist", b"Tag Album"
+        )
+
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file2")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file3")
 
     def test_ignore_media_files(self):
         self._run_importer()
@@ -51,10 +138,19 @@ class CopyFileArtifactsFromFlatDirectoryTest(CopyFileArtifactsTestCase):
 
         self._run_importer()
 
+        self.assert_number_of_files_in_dir(
+            5, self.lib_dir, b"Tag Artist", b"Tag Album"
+        )
+
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file2")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file3")
+
         self.assert_not_in_import_dir(b"the_album", b"artifact.file")
+        self.assert_not_in_import_dir(b"the_album", b"artifact2.file")
         self.assert_not_in_import_dir(b"the_album", b"artifact.file2")
+        self.assert_not_in_import_dir(b"the_album", b"artifact.file3")
 
     def test_prune_import_directory_when_emptied(self):
         """
@@ -77,9 +173,12 @@ class CopyFileArtifactsFromFlatDirectoryTest(CopyFileArtifactsTestCase):
 
         self._run_importer()
 
-        self.assert_number_of_files_in_dir(3, self.import_dir, b"the_album")
+        self.assert_number_of_files_in_dir(5, self.import_dir, b"the_album")
+
         self.assert_in_import_dir(b"the_album", b"artifact.file")
+        self.assert_in_import_dir(b"the_album", b"artifact2.file")
         self.assert_in_import_dir(b"the_album", b"artifact.file2")
+        self.assert_in_import_dir(b"the_album", b"artifact.file3")
 
     def test_rename_when_copying(self):
         config["copyfileartifacts"]["extensions"] = ".file"

--- a/tests/test_printignored.py
+++ b/tests/test_printignored.py
@@ -26,6 +26,9 @@ class CopyFileArtifactsPrintIgnoredTest(CopyFileArtifactsTestCase):
         self.assert_not_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"artifact.file2"
         )
+        self.assert_not_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"artifact.file3"
+        )
 
         # check output log
         logs = [line for line in logs if line.startswith("copyfileartifacts:")]
@@ -41,6 +44,9 @@ class CopyFileArtifactsPrintIgnoredTest(CopyFileArtifactsTestCase):
         self.assert_not_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"artifact.file2"
         )
+        self.assert_not_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"artifact.file3"
+        )
 
         # check output log
         logs = [line for line in logs if line.startswith("copyfileartifacts:")]
@@ -49,5 +55,6 @@ class CopyFileArtifactsPrintIgnoredTest(CopyFileArtifactsTestCase):
             [
                 "copyfileartifacts: Ignored files:",
                 "copyfileartifacts:    artifact.file2",
+                "copyfileartifacts:    artifact.file3",
             ],
         )

--- a/tests/test_reimport.py
+++ b/tests/test_reimport.py
@@ -24,6 +24,7 @@ class CopyFileArtifactsReimportTest(CopyFileArtifactsTestCase):
                     Tag Album/
                         Tag Title 1.mp3
                         artifact.file
+                        artifact2.file
         """
         super(CopyFileArtifactsReimportTest, self).setUp()
 
@@ -110,9 +111,10 @@ class CopyFileArtifactsReimportTest(CopyFileArtifactsTestCase):
         self._run_importer()
 
         self.assert_number_of_files_in_dir(
-            2, self.lib_dir, b"Tag Artist", b"Tag Album"
+            3, self.lib_dir, b"Tag Artist", b"Tag Album"
         )
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
 
     def test_do_nothing_when_paths_do_not_change_with_move_import(self):
         self._setup_import_session(
@@ -122,10 +124,8 @@ class CopyFileArtifactsReimportTest(CopyFileArtifactsTestCase):
         log.debug("--- second import")
         self._run_importer()
 
-        self.assert_number_of_files_in_dir(
-            2, self.lib_dir, b"Tag Artist", b"Tag Album"
-        )
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
 
     def test_rename_with_copy_import(self):
         config["paths"]["ext:file"] = str(


### PR DESCRIPTION
This adds new optional config parameters:

- `filenames`: allow for specification per filename (e.g., whitelist items)
- `exclude`: items to exclude, by filename (e.g., blacklist items)

`exclude`-d files take precedence over other matching, meaning `exclude` will trump other matches by either `extensions` or `filenames`.

This also removes some Python 2 conversion cruft.