### PR TITLE
Introduce "paired" file copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,15 @@ trump other matches by either `extensions` or `filenames`.
 
 ### Renaming files
 
-Renaming works in much the same way as beets [Path Formats](http://beets.readthedocs.org/en/stable/reference/pathformat.html)
-with the following considerations:
+Renaming works in much the same way as beets [Path Formats](http://beets.readthedocs.org/en/stable/reference/pathformat.html).
+This plugin supports the below new path queries (from least to most specific).
+Each takes a single corresponding value.
+
+- `ext:`
+- `paired_ext:`
+- `filename:`
+
+Renaming has the following considerations:
 
 - The fields available are `$artist`, `$albumartist`, `$album`, `$albumpath`,
   `$old_filename` (filename of the extra/artifcat file before its renamed),

--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ copyfileartifacts:
   extensions: .*
 ```
 
+It can look for and target "pairs" (files having the same name as a matching or
+"paired" media item/track):
+
+```yaml
+copyfileartifacts:
+  pairing: True
+```
+
+And target/include only paired files:
+
+```yaml
+copyfileartifacts:
+  pairing: True
+  pairing_only: True
+```
+
 It can also exclude files by name:
 
 ```yaml
@@ -84,18 +100,20 @@ trump other matches by either `extensions` or `filenames`.
 ### Renaming files
 
 Renaming works in much the same way as beets [Path Formats](http://beets.readthedocs.org/en/stable/reference/pathformat.html)
-with the following limitations:
+with the following considerations:
 
 - The fields available are `$artist`, `$albumartist`, `$album`, `$albumpath`,
   `$old_filename` (filename of the extra/artifcat file before its renamed),
-  and `$item_old_filename` (filename of the item/track triggering it, before
+  `$medianame_old` (filename of the item/track triggering it, _before_
+  its renamed), and `$medianame_new` (filename of the item/track triggering it, _after_
   its renamed).
 - The full set of
   [built in functions](http://beets.readthedocs.org/en/stable/reference/pathformat.html#functions)
   are also supported, with the exception of `%aunique` - which will
   return an empty string.
-- `filename:` path query will take precedence over `ext:` if a given file
-  qualifies for both
+- `filename:` path query will take precedence over `paired_ext:` and `ext:` if
+  a given file qualifies for them. `paired_ext:` takes precedence over `ext:`,
+  but is not required.
 
 Each template string uses a query syntax for each of the file
 extensions. For example the following template string will be applied to
@@ -134,10 +152,13 @@ paths:
   singleton: Singletons/$artist - $title
   ext:.log: $albumpath/$artist - $album
   ext:.cue: $albumpath/$artist - $album
+  paired_ext:.lrc: $albumpath/$medianame_old
   filename:cover.jpg: $albumpath/cover
 
 copyfileartifacts:
-  extensions: .cue .log .jpg
+  extensions: .cue .log .jpg .lrc
+  filename: "cover.jpg"
+  pairing: True
   print_ignored: yes
 ```
 

--- a/beetsplug/copyfileartifacts.py
+++ b/beetsplug/copyfileartifacts.py
@@ -256,6 +256,11 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
                         [{"path": shared_artifact, "paired": False}]
                     )
 
+            self._log.warning(
+                b", ".join(self._shared_artifacts[source_path]).decode("utf8")
+            )
+
+            self._log.warning(b", ".join(artifacts).decode("utf8"))
             self._shared_artifacts[source_path] = []
 
             self.process_artifacts(artifacts, item["mapping"], False)
@@ -278,11 +283,13 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
 
             # Skip as another plugin or beets has already moved this file
             if not os.path.exists(source_file):
+                self._log.warning("first fail: " + str(source_file))
                 ignored_files.append(source_file)
                 continue
 
             # Skip if filename is explicitly in `exclude`
             if filename.decode("utf8") in self.exclude:
+                self._log.warning("second fail: " + str(source_file))
                 ignored_files.append(source_file)
                 continue
 
@@ -295,6 +302,7 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
                 and file_ext.decode("utf8") not in self.extensions
                 and filename.decode("utf8") not in self.filenames
             ):
+                self._log.warning("third fail: " + str(source_file))
                 ignored_files.append(source_file)
                 continue
 
@@ -302,6 +310,7 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
             if os.path.exists(dest_file) and filecmp.cmp(
                 source_file, dest_file
             ):
+                self._log.warning("fourth fail: " + str(source_file))
                 ignored_files.append(source_file)
                 continue
 

--- a/beetsplug/copyfileartifacts.py
+++ b/beetsplug/copyfileartifacts.py
@@ -205,6 +205,7 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
                                 "mapping": self._generate_mapping(
                                     item, destination
                                 ),
+                                "source_path": source_path,
                             }
                         ]
                     )
@@ -235,6 +236,7 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
                 {
                     "files": queue_files,
                     "mapping": self._generate_mapping(item, destination),
+                    "source_path": source_path,
                 }
             ]
         )
@@ -248,7 +250,7 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
         for item in self._process_queue:
             artifacts = item["files"]
 
-            source_path = os.path.dirname(item["files"][0]["path"])
+            source_path = item["source_path"]
 
             if not self.pairing_only:
                 for shared_artifact in self._shared_artifacts[source_path]:

--- a/beetsplug/copyfileartifacts.py
+++ b/beetsplug/copyfileartifacts.py
@@ -176,7 +176,7 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
         source_path = os.path.dirname(source)
         dest_path = os.path.dirname(destination)
 
-        paired_files = []
+        queue_files = []
 
         # Check if this path has already been processed
         if source_path in self._dirs_seen:
@@ -191,17 +191,17 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
                         os.path.basename(filepath)
                     )
                     if file_name == item_source_filename:
-                        paired_files.append({"path": filepath, "paired": True})
+                        queue_files.append({"path": filepath, "paired": True})
 
                         # Remove from shared artifacts, as the item-move will
                         # handle this file.
                         self._shared_artifacts[source_path].remove(filepath)
 
-                if paired_files:
+                if queue_files:
                     self._process_queue.extend(
                         [
                             {
-                                "files": paired_files,
+                                "files": queue_files,
                                 "mapping": self._generate_mapping(
                                     item, destination
                                 ),
@@ -224,16 +224,16 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
                     continue
 
                 if not self.pairing:
-                    paired_files.append({"path": source_file, "paired": False})
+                    queue_files.append({"path": source_file, "paired": False})
                 elif self.pairing and file_name == item_source_filename:
-                    paired_files.append({"path": source_file, "paired": True})
+                    queue_files.append({"path": source_file, "paired": True})
                 else:
                     non_handled_files.append(source_file)
 
         self._process_queue.extend(
             [
                 {
-                    "files": paired_files,
+                    "files": queue_files,
                     "mapping": self._generate_mapping(item, destination),
                 }
             ]

--- a/beetsplug/copyfileartifacts.py
+++ b/beetsplug/copyfileartifacts.py
@@ -155,6 +155,8 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
         mapping["item_old_filename"] = filename_old
         mapping["item_new_filename"] = filename_new
 
+        self._log.warning(str(filename_new))
+
         return mapping
 
     def collect_artifacts(self, item, source, destination):
@@ -169,10 +171,17 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
 
         # Check if this path has already been processed
         if source_path in self._dirs_seen:
-
+            self._log.warning("Pairing==========" + str(self.pairing))
+            self._log.warning("GAVIN==========" + str(item_source_filename))
+            self._log.warning(
+                "Shared=========="
+                + b", ".join(self._shared_artifacts[source_path]).decode("utf8")
+            )
             # Check to see if "pairing" is enabled and, if so, if there are
             # artifacts to look at
             if self.pairing and self._shared_artifacts[source_path]:
+
+                self._log.warning(str(item_source_filename))
 
                 # Iterate through shared artifacts to find paired matches
                 for filepath in self._shared_artifacts[source_path]:

--- a/beetsplug/copyfileartifacts.py
+++ b/beetsplug/copyfileartifacts.py
@@ -179,7 +179,7 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
                         os.path.basename(filepath)
                     )
                     if file_name == item_source_filename:
-                        paired_files.append((filepath, True))
+                        paired_files.append({"path": filepath, "paired": True})
 
                         # Remove from shared artifacts, as the item-move will
                         # handle this file.
@@ -212,9 +212,9 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
                     continue
 
                 if not self.pairing:
-                    paired_files.append((source_file, False))
+                    paired_files.append({"path": source_file, "paired": False})
                 if self.pairing and file_name == item_source_filename:
-                    paired_files.append((source_file, True))
+                    paired_files.append({"path": source_file, "paired": True})
                 else:
                     non_handled_files.append(source_file)
 
@@ -236,11 +236,13 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
         for item in self._process_queue:
             artifacts = item["files"]
 
-            source_path = os.path.dirname(item["files"][0][0])
+            source_path = os.path.dirname(item["files"][0]["path"])
 
             if not self.pairing_only:
                 for shared_artifact in self._shared_artifacts[source_path]:
-                    artifacts.extend([(shared_artifact, False)])
+                    artifacts.extend(
+                        [{"path": shared_artifact, "paired": False}]
+                    )
 
             self._shared_artifacts[source_path] = []
 
@@ -252,7 +254,9 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
 
         ignored_files = []
 
-        for source_file, paired in source_files:
+        for artifact in source_files:
+            source_file = artifact["path"]
+
             # self._log.warning(str(paired))
 
             source_path = os.path.dirname(source_file)

--- a/beetsplug/copyfileartifacts.py
+++ b/beetsplug/copyfileartifacts.py
@@ -22,6 +22,7 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
                 "exclude": "",
                 "print_ignored": False,
                 "pairing": False,
+                "pairing_only": False,
             }
         )
 
@@ -34,6 +35,7 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
         self.exclude = self.config["exclude"].as_str_seq()
         self.print_ignored = self.config["print_ignored"].get()
         self.pairing = self.config["pairing"].get()
+        self.pairing_only = self.config["pairing_only"].get()
 
         ext_len = len("ext:")
         filename_len = len("filename:")
@@ -236,8 +238,9 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
 
             source_path = os.path.dirname(item["files"][0][0])
 
-            for shared_artifact in self._shared_artifacts[source_path]:
-                artifacts.extend([(shared_artifact, False)])
+            if not self.pairing_only:
+                for shared_artifact in self._shared_artifacts[source_path]:
+                    artifacts.extend([(shared_artifact, False)])
 
             self._shared_artifacts[source_path] = []
 

--- a/beetsplug/copyfileartifacts.py
+++ b/beetsplug/copyfileartifacts.py
@@ -144,6 +144,7 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
         album_path = os.path.dirname(destination)
         mapping["albumpath"] = beets.util.displayable_path(album_path)
 
+        # TODO: Retool to utilize the OS's path separator
         # pathsep = beets.config["path_sep_replace"].get(str)
         strpath_old = beets.util.displayable_path(item.path)
         filename_old, fileext = os.path.splitext(os.path.basename(strpath_old))

--- a/beetsplug/copyfileartifacts.py
+++ b/beetsplug/copyfileartifacts.py
@@ -225,7 +225,7 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
 
                 if not self.pairing:
                     paired_files.append({"path": source_file, "paired": False})
-                if self.pairing and file_name == item_source_filename:
+                elif self.pairing and file_name == item_source_filename:
                     paired_files.append({"path": source_file, "paired": True})
                 else:
                     non_handled_files.append(source_file)
@@ -256,11 +256,6 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
                         [{"path": shared_artifact, "paired": False}]
                     )
 
-            self._log.warning(
-                b", ".join(self._shared_artifacts[source_path]).decode("utf8")
-            )
-
-            self._log.warning(b", ".join(artifacts).decode("utf8"))
             self._shared_artifacts[source_path] = []
 
             self.process_artifacts(artifacts, item["mapping"], False)
@@ -283,13 +278,11 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
 
             # Skip as another plugin or beets has already moved this file
             if not os.path.exists(source_file):
-                self._log.warning("first fail: " + str(source_file))
                 ignored_files.append(source_file)
                 continue
 
             # Skip if filename is explicitly in `exclude`
             if filename.decode("utf8") in self.exclude:
-                self._log.warning("second fail: " + str(source_file))
                 ignored_files.append(source_file)
                 continue
 
@@ -302,7 +295,6 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
                 and file_ext.decode("utf8") not in self.extensions
                 and filename.decode("utf8") not in self.filenames
             ):
-                self._log.warning("third fail: " + str(source_file))
                 ignored_files.append(source_file)
                 continue
 
@@ -310,7 +302,6 @@ class CopyFileArtifactsPlugin(BeetsPlugin):
             if os.path.exists(dest_file) and filecmp.cmp(
                 source_file, dest_file
             ):
-                self._log.warning("fourth fail: " + str(source_file))
                 ignored_files.append(source_file)
                 continue
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -113,6 +113,10 @@ class CopyFileArtifactsTestCase(_common.TestCase):
             ("comp:true", os.path.join("compilations", "$album", "$title")),
         ]
 
+    def _create_file(self, album_path, filename):
+        """Creates a file in a specific location."""
+        open(os.path.join(album_path, filename), "a").close()
+
     def _create_flat_import_dir(self, media_files=3, generate_pair=True):
         """
         Creates a directory with media files and artifacts.
@@ -140,10 +144,10 @@ class CopyFileArtifactsTestCase(_common.TestCase):
         os.makedirs(album_path)
 
         # Create artifacts
-        open(os.path.join(album_path, b"artifact.file"), "a").close()
-        open(os.path.join(album_path, b"artifact2.file"), "a").close()
-        open(os.path.join(album_path, b"artifact.nfo"), "a").close()
-        open(os.path.join(album_path, b"artifact.lrc"), "a").close()
+        self._create_file(album_path, b"artifact.file")
+        self._create_file(album_path, b"artifact2.file")
+        self._create_file(album_path, b"artifact.nfo")
+        self._create_file(album_path, b"artifact.lrc")
 
         # Number of desired media
         self._media_count = self._pairs_count = media_files
@@ -183,12 +187,9 @@ class CopyFileArtifactsTestCase(_common.TestCase):
 
             if generate_pair:
                 # Create paired artifact
-                open(
-                    os.path.join(
-                        album_path, f"{trackname}.lrc".encode("utf-8")
-                    ),
-                    "a",
-                ).close()
+                self._create_file(
+                    album_path, f"{trackname}.lrc".encode("utf-8")
+                )
         return media_list
 
     def _create_medium(

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -128,8 +128,8 @@ class CopyFileArtifactsTestCase(_common.TestCase):
                     track_3.mp3
                     artifact.file
                     artifact2.file
-                    artifact.file2
-                    artifact.file3
+                    artifact.nfo
+                    artifact.lrc
                     track_1.lrc
                     track_2.lrc
                     track_3.lrc

--- a/tests/test_flatdirectory.py
+++ b/tests/test_flatdirectory.py
@@ -178,7 +178,7 @@ class CopyFileArtifactsFromFlatDirectoryTest(CopyFileArtifactsTestCase):
         """By default, all eligible files are grabbed with the first item."""
         config["copyfileartifacts"]["extensions"] = ".file"
         config["paths"]["ext:file"] = str(
-            "$albumpath/$item_old_filename - $old_filename"
+            "$albumpath/$medianame_old - $old_filename"
         )
 
         self._run_importer()

--- a/tests/test_flatdirectory.py
+++ b/tests/test_flatdirectory.py
@@ -36,12 +36,8 @@ class CopyFileArtifactsFromFlatDirectoryTest(CopyFileArtifactsTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
 
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file2"
-        )
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file3"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
     def test_exclude_artifacts_matching_configured_exclude(self):
         config["copyfileartifacts"]["extensions"] = ".file"
@@ -58,12 +54,8 @@ class CopyFileArtifactsFromFlatDirectoryTest(CopyFileArtifactsTestCase):
         self.assert_not_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"artifact2.file"
         )
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file2"
-        )
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file3"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
     def test_only_copy_artifacts_matching_configured_filename(self):
         config["copyfileartifacts"]["extensions"] = ""
@@ -80,12 +72,8 @@ class CopyFileArtifactsFromFlatDirectoryTest(CopyFileArtifactsTestCase):
         self.assert_not_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"artifact2.file"
         )
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file2"
-        )
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file3"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
     def test_only_copy_artifacts_matching_configured_extension_and_filename(
         self,
@@ -103,9 +91,7 @@ class CopyFileArtifactsFromFlatDirectoryTest(CopyFileArtifactsTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
 
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file3"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
     def test_copy_all_artifacts_by_default(self):
         self._run_importer()

--- a/tests/test_flatdirectory.py
+++ b/tests/test_flatdirectory.py
@@ -22,6 +22,8 @@ class CopyFileArtifactsFromFlatDirectoryTest(CopyFileArtifactsTestCase):
         self._create_flat_import_dir()
         self._setup_import_session(autotag=False)
 
+        self._base_file_count = self._media_count + self._pairs_count
+
     def test_only_copy_artifacts_matching_configured_extension(self):
         config["copyfileartifacts"]["extensions"] = ".file"
 
@@ -89,7 +91,7 @@ class CopyFileArtifactsFromFlatDirectoryTest(CopyFileArtifactsTestCase):
         self,
     ):
         config["copyfileartifacts"]["extensions"] = ".file"
-        config["copyfileartifacts"]["filenames"] = "artifact.file2"
+        config["copyfileartifacts"]["filenames"] = "artifact.nfo"
 
         self._run_importer()
 
@@ -99,9 +101,7 @@ class CopyFileArtifactsFromFlatDirectoryTest(CopyFileArtifactsTestCase):
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
-        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file2")
-
-        self.assert_number_of_files_in_dir(7, self.import_dir, b"the_album")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
 
         self.assert_not_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"artifact.file3"
@@ -111,25 +111,25 @@ class CopyFileArtifactsFromFlatDirectoryTest(CopyFileArtifactsTestCase):
         self._run_importer()
 
         self.assert_number_of_files_in_dir(
-            self._media_count + 4, self.lib_dir, b"Tag Artist", b"Tag Album"
+            self._base_file_count + 4, self.lib_dir, b"Tag Artist", b"Tag Album"
         )
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
-        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file2")
-        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file3")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
     def test_copy_artifacts(self):
         self._run_importer()
 
         self.assert_number_of_files_in_dir(
-            self._media_count + 4, self.lib_dir, b"Tag Artist", b"Tag Album"
+            self._base_file_count + 4, self.lib_dir, b"Tag Artist", b"Tag Album"
         )
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
-        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file2")
-        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file3")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
     def test_ignore_media_files(self):
         self._run_importer()
@@ -142,18 +142,18 @@ class CopyFileArtifactsFromFlatDirectoryTest(CopyFileArtifactsTestCase):
         self._run_importer()
 
         self.assert_number_of_files_in_dir(
-            self._media_count + 4, self.lib_dir, b"Tag Artist", b"Tag Album"
+            self._base_file_count + 4, self.lib_dir, b"Tag Artist", b"Tag Album"
         )
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
-        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file2")
-        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file3")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
         self.assert_not_in_import_dir(b"the_album", b"artifact.file")
         self.assert_not_in_import_dir(b"the_album", b"artifact2.file")
-        self.assert_not_in_import_dir(b"the_album", b"artifact.file2")
-        self.assert_not_in_import_dir(b"the_album", b"artifact.file3")
+        self.assert_not_in_import_dir(b"the_album", b"artifact.nfo")
+        self.assert_not_in_import_dir(b"the_album", b"artifact.lrc")
 
     def test_do_nothing_when_not_copying_or_moving(self):
         """
@@ -166,13 +166,13 @@ class CopyFileArtifactsFromFlatDirectoryTest(CopyFileArtifactsTestCase):
         self._run_importer()
 
         self.assert_number_of_files_in_dir(
-            self._media_count + 4, self.import_dir, b"the_album"
+            self._base_file_count + 4, self.import_dir, b"the_album"
         )
 
         self.assert_in_import_dir(b"the_album", b"artifact.file")
         self.assert_in_import_dir(b"the_album", b"artifact2.file")
-        self.assert_in_import_dir(b"the_album", b"artifact.file2")
-        self.assert_in_import_dir(b"the_album", b"artifact.file3")
+        self.assert_in_import_dir(b"the_album", b"artifact.nfo")
+        self.assert_in_import_dir(b"the_album", b"artifact.lrc")
 
     def test_artifacts_copymove_on_first_media_by_default(self):
         """By default, all eligible files are grabbed with the first item."""

--- a/tests/test_flatdirectory.py
+++ b/tests/test_flatdirectory.py
@@ -36,8 +36,32 @@ class CopyFileArtifactsFromFlatDirectoryTest(CopyFileArtifactsTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
 
+        self.assert_in_import_dir(b"the_album", b"artifact.nfo")
+        self.assert_in_import_dir(b"the_album", b"artifact.lrc")
+
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
+
+    def test_exact_matching_configured_extension(self):
+        config["copyfileartifacts"]["extensions"] = ".file"
+
+        self._create_file(
+            os.path.join(self.import_dir, b"the_album"), b"artifact.file2"
+        )
+
+        self._run_importer()
+
+        self.assert_number_of_files_in_dir(
+            self._media_count + 2, self.lib_dir, b"Tag Artist", b"Tag Album"
+        )
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
+
+        self.assert_in_import_dir(b"the_album", b"artifact.file2")
+        self.assert_not_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"artifact.file2"
+        )
 
     def test_exclude_artifacts_matching_configured_exclude(self):
         config["copyfileartifacts"]["extensions"] = ".file"

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -30,7 +30,7 @@ class CopyFileArtifactsPairingTest(CopyFileArtifactsTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_pairing_only_requires_pairing_enabled(self):
+    def test_pairingonly_requires_pairing_enabled(self):
         self._create_flat_import_dir(media_files=3)
         self._setup_import_session(autotag=False)
 
@@ -68,7 +68,34 @@ class CopyFileArtifactsPairingTest(CopyFileArtifactsTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_pairing_only_disabled_copies_all_matches(self):
+    def test_pairing_enabled_works_without_pairs(self):
+        self._create_flat_import_dir(media_files=2, generate_pair=False)
+        self._setup_import_session(autotag=False)
+
+        config["copyfileartifacts"]["extensions"] = ".lrc"
+        config["copyfileartifacts"]["pairing"] = True
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
+
+    def test_pairing_does_not_require_pairs_for_all_media(self):
+        self._create_flat_import_dir(media_files=2, generate_pair=False)
+        self._setup_import_session(autotag=False)
+
+        config["copyfileartifacts"]["extensions"] = ".lrc"
+        config["copyfileartifacts"]["pairing"] = True
+
+        self._create_file(
+            os.path.join(self.import_dir, b"the_album"), b"track_1.lrc"
+        )
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
+
+    def test_pairingonly_disabled_copies_all_matches(self):
         self._create_flat_import_dir(media_files=2)
         self._setup_import_session(autotag=False)
 
@@ -82,7 +109,7 @@ class CopyFileArtifactsPairingTest(CopyFileArtifactsTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_pairing_only_enabled_copies_all_matches(self):
+    def test_pairingonly_enabled_copies_all_matches(self):
         self._create_flat_import_dir(media_files=2)
         self._setup_import_session(autotag=False)
 
@@ -94,4 +121,24 @@ class CopyFileArtifactsPairingTest(CopyFileArtifactsTestCase):
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
+
+    def test_pairingonly_does_not_require_pairs_for_all_media(self):
+        self._create_flat_import_dir(media_files=2, generate_pair=False)
+        self._setup_import_session(autotag=False)
+
+        config["copyfileartifacts"]["extensions"] = ".lrc"
+        config["copyfileartifacts"]["pairing"] = True
+        config["copyfileartifacts"]["pairing_only"] = True
+
+        self._create_file(
+            os.path.join(self.import_dir, b"the_album"), b"track_1.lrc"
+        )
+
+        self._run_importer()
+
+        self.assert_in_import_dir(b"the_album", b"track_1.lrc")
+        self.assert_in_import_dir(b"the_album", b"artifact.lrc")
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -19,13 +19,36 @@ class CopyFileArtifactsPairingTest(CopyFileArtifactsTestCase):
     def setUp(self):
         super(CopyFileArtifactsPairingTest, self).setUp()
 
+    def test_pairing_default_is_disabled(self):
+        self._create_flat_import_dir(media_files=1)
+        self._setup_import_session(autotag=False)
+
+        config["copyfileartifacts"]["extensions"] = ".lrc"
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
+
+    def test_pairing_only_requires_pairing_enabled(self):
+        self._create_flat_import_dir(media_files=3)
+        self._setup_import_session(autotag=False)
+
+        config["copyfileartifacts"]["extensions"] = ".lrc"
+        config["copyfileartifacts"]["pairing"] = False
+        config["copyfileartifacts"]["pairing_only"] = True
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
+
     def test_pairing_disabled_copies_all_matches(self):
         self._create_flat_import_dir(media_files=1)
         self._setup_import_session(autotag=False)
 
         config["copyfileartifacts"]["extensions"] = ".lrc"
         config["copyfileartifacts"]["pairing"] = False
-        config["paths"]["paired-ext:lrc"] = str("$albumpath/$medianame")
 
         self._run_importer()
 

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -38,10 +38,37 @@ class CopyFileArtifactsPairingTest(CopyFileArtifactsTestCase):
 
         config["copyfileartifacts"]["extensions"] = ".lrc"
         config["copyfileartifacts"]["pairing"] = True
-        config["paths"]["paired-ext:lrc"] = str("$albumpath/$medianame")
 
         self._run_importer()
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
+
+    def test_pairing_only_disabled_copies_all_matches(self):
+        self._create_flat_import_dir(media_files=2)
+        self._setup_import_session(autotag=False)
+
+        config["copyfileartifacts"]["extensions"] = ".lrc"
+        config["copyfileartifacts"]["pairing"] = True
+        config["copyfileartifacts"]["pairing_only"] = False
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
+
+    def test_pairing_only_enabled_copies_all_matches(self):
+        self._create_flat_import_dir(media_files=2)
+        self._setup_import_session(autotag=False)
+
+        config["copyfileartifacts"]["extensions"] = ".lrc"
+        config["copyfileartifacts"]["pairing"] = True
+        config["copyfileartifacts"]["pairing_only"] = True
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -1,0 +1,47 @@
+import logging
+import os
+import sys
+
+import pytest
+from beets import config
+
+from tests.helper import CopyFileArtifactsTestCase
+
+log = logging.getLogger("beets")
+
+
+class CopyFileArtifactsPairingTest(CopyFileArtifactsTestCase):
+    """
+    Tests to check that copyfileartifacts renames as expected for custom path
+    formats (both by extension and filename).
+    """
+
+    def setUp(self):
+        super(CopyFileArtifactsPairingTest, self).setUp()
+
+    def test_pairing_disabled_copies_all_matches(self):
+        self._create_flat_import_dir(media_files=1)
+        self._setup_import_session(autotag=False)
+
+        config["copyfileartifacts"]["extensions"] = ".lrc"
+        config["copyfileartifacts"]["pairing"] = False
+        config["paths"]["paired-ext:lrc"] = str("$albumpath/$medianame")
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
+
+    def test_pairing_enabled_copies_all_matches(self):
+        self._create_flat_import_dir(media_files=2)
+        self._setup_import_session(autotag=False)
+
+        config["copyfileartifacts"]["extensions"] = ".lrc"
+        config["copyfileartifacts"]["pairing"] = True
+        config["paths"]["paired-ext:lrc"] = str("$albumpath/$medianame")
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")

--- a/tests/test_printignored.py
+++ b/tests/test_printignored.py
@@ -33,7 +33,7 @@ class CopyFileArtifactsPrintIgnoredTest(CopyFileArtifactsTestCase):
 
         # check output log
         logs = [line for line in logs if line.startswith("copyfileartifacts:")]
-        # self.assertEqual(logs, [])
+        self.assertEqual(logs, [])
 
     def test_print_ignored(self):
         config["copyfileartifacts"]["print_ignored"] = True

--- a/tests/test_printignored.py
+++ b/tests/test_printignored.py
@@ -33,9 +33,8 @@ class CopyFileArtifactsPrintIgnoredTest(CopyFileArtifactsTestCase):
 
         # check output log
         logs = [line for line in logs if line.startswith("copyfileartifacts:")]
-        self.assertEqual(logs, [])
+        # self.assertEqual(logs, [])
 
-    @pytest.mark.skip(reason="TODO")
     def test_print_ignored(self):
         config["copyfileartifacts"]["print_ignored"] = True
         config["copyfileartifacts"]["extensions"] = ".file .lrc"

--- a/tests/test_printignored.py
+++ b/tests/test_printignored.py
@@ -24,12 +24,8 @@ class CopyFileArtifactsPrintIgnoredTest(CopyFileArtifactsTestCase):
         with capture_log() as logs:
             self._run_importer()
 
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file2"
-        )
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file3"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
         # check output log
         logs = [line for line in logs if line.startswith("copyfileartifacts:")]

--- a/tests/test_printignored.py
+++ b/tests/test_printignored.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+import pytest
 from beets import config
 
 from tests.helper import CopyFileArtifactsTestCase, capture_log
@@ -34,19 +35,15 @@ class CopyFileArtifactsPrintIgnoredTest(CopyFileArtifactsTestCase):
         logs = [line for line in logs if line.startswith("copyfileartifacts:")]
         self.assertEqual(logs, [])
 
+    @pytest.mark.skip(reason="TODO")
     def test_print_ignored(self):
         config["copyfileartifacts"]["print_ignored"] = True
-        config["copyfileartifacts"]["extensions"] = ".file"
+        config["copyfileartifacts"]["extensions"] = ".file .lrc"
 
         with capture_log() as logs:
             self._run_importer()
 
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file2"
-        )
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file3"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
 
         # check output log
         logs = [line for line in logs if line.startswith("copyfileartifacts:")]
@@ -54,7 +51,6 @@ class CopyFileArtifactsPrintIgnoredTest(CopyFileArtifactsTestCase):
             logs,
             [
                 "copyfileartifacts: Ignored files:",
-                "copyfileartifacts:    artifact.file2",
-                "copyfileartifacts:    artifact.file3",
+                "copyfileartifacts:    artifact.nfo",
             ],
         )

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -77,6 +77,18 @@ class CopyFileArtifactsRenameTest(CopyFileArtifactsTestCase):
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.file")
 
+    def test_rename_field_item_new_filename(self):
+        config["copyfileartifacts"]["extensions"] = ".lrc"
+        config["copyfileartifacts"]["pairing"] = True
+        config["copyfileartifacts"]["paring_only"] = True
+        config["paths"]["ext:lrc"] = str("$albumpath/$item_new_filename")
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 1.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 2.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 3.lrc")
+
     def test_rename_when_copying(self):
         config["copyfileartifacts"]["extensions"] = ".file"
         config["paths"]["ext:file"] = str("$albumpath/$artist - $album")

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -69,19 +69,76 @@ class CopyFileArtifactsRenameTest(CopyFileArtifactsTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
 
-    def test_rename_field_item_old_filename(self):
+    def test_rename_field_medianame_old(self):
         config["copyfileartifacts"]["extensions"] = ".file"
-        config["paths"]["ext:file"] = str("$albumpath/$item_old_filename")
+        config["paths"]["ext:file"] = str("$albumpath/$medianame_old")
 
         self._run_importer()
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.file")
 
-    def test_rename_field_item_new_filename(self):
+    def test_rename_paired_ext(self):
         config["copyfileartifacts"]["extensions"] = ".lrc"
         config["copyfileartifacts"]["pairing"] = True
         config["copyfileartifacts"]["paring_only"] = True
-        config["paths"]["ext:lrc"] = str("$albumpath/$item_new_filename")
+        config["paths"]["paired_ext:lrc"] = str("$albumpath/$medianame_new")
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 1.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 2.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 3.lrc")
+
+    def test_rename_paired_ext_does_not_conflict_with_ext(self):
+        config["copyfileartifacts"]["extensions"] = ".lrc"
+        config["copyfileartifacts"]["pairing"] = True
+        config["copyfileartifacts"]["paring_only"] = True
+        config["paths"]["ext:lrc"] = str("$albumpath/1 $old_filename")
+        config["paths"]["paired_ext:lrc"] = str("$albumpath/$medianame_new")
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"1 artifact.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 1.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 2.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 3.lrc")
+
+    def test_rename_paired_ext_is_prioritized_over_ext(self):
+        config["copyfileartifacts"]["extensions"] = ".lrc"
+        config["copyfileartifacts"]["pairing"] = True
+        config["copyfileartifacts"]["paring_only"] = True
+        config["paths"]["paired_ext:lrc"] = str("$albumpath/$medianame_new")
+        config["paths"]["ext:lrc"] = str("$albumpath/1 $old_filename")
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"1 artifact.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 1.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 2.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 3.lrc")
+
+    def test_rename_filename_is_prioritized_over_paired_ext(self):
+        config["copyfileartifacts"]["extensions"] = ".lrc"
+        config["copyfileartifacts"]["pairing"] = True
+        config["copyfileartifacts"]["paring_only"] = True
+        config["paths"]["paired_ext:lrc"] = str("$albumpath/$medianame_new")
+        config["paths"]["filename:track_1.lrc"] = str(
+            "$albumpath/1 $old_filename"
+        )
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"1 track_1.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 2.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 3.lrc")
+
+    def test_rename_field_medianame_new(self):
+        config["copyfileartifacts"]["extensions"] = ".lrc"
+        config["copyfileartifacts"]["pairing"] = True
+        config["copyfileartifacts"]["paring_only"] = True
+        config["paths"]["ext:lrc"] = str("$albumpath/$medianame_new")
 
         self._run_importer()
 

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -102,9 +102,9 @@ class CopyFileArtifactsRenameTest(CopyFileArtifactsTestCase):
         self.assert_not_in_import_dir(b"the_album", b"artifact.file")
 
     def test_rename_period_is_optional_for_ext(self):
-        config["copyfileartifacts"]["extensions"] = ".file .file2"
+        config["copyfileartifacts"]["extensions"] = ".file .nfo"
         config["paths"]["ext:file"] = str("$albumpath/$artist - $album")
-        config["paths"]["ext:.file2"] = str("$albumpath/$artist - $album 2")
+        config["paths"]["ext:.nfo"] = str("$albumpath/$artist - $album 2")
         config["import"]["move"] = True
 
         self._run_importer()
@@ -113,10 +113,10 @@ class CopyFileArtifactsRenameTest(CopyFileArtifactsTestCase):
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
         )
         self.assert_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album 2.file2"
+            b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album 2.nfo"
         )
         self.assert_not_in_import_dir(b"the_album", b"artifact.file")
-        self.assert_not_in_import_dir(b"the_album", b"artifact.file2")
+        self.assert_not_in_import_dir(b"the_album", b"artifact.nfo")
 
     def test_rename_ignores_file_when_name_conflicts(self):
         config["copyfileartifacts"]["extensions"] = ".file"
@@ -133,9 +133,9 @@ class CopyFileArtifactsRenameTest(CopyFileArtifactsTestCase):
         self.assert_in_import_dir(b"the_album", b"artifact2.file")
 
     def test_rename_multiple_extensions(self):
-        config["copyfileartifacts"]["extensions"] = ".file .file2"
+        config["copyfileartifacts"]["extensions"] = ".file .nfo"
         config["paths"]["ext:file"] = str("$albumpath/$artist - $album")
-        config["paths"]["ext:file2"] = str("$albumpath/$artist - $album")
+        config["paths"]["ext:nfo"] = str("$albumpath/$artist - $album")
         config["import"]["move"] = True
 
         self._run_importer()
@@ -144,10 +144,10 @@ class CopyFileArtifactsRenameTest(CopyFileArtifactsTestCase):
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
         )
         self.assert_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file2"
+            b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.nfo"
         )
         self.assert_not_in_import_dir(b"the_album", b"artifact.file")
-        self.assert_not_in_import_dir(b"the_album", b"artifact.file2")
+        self.assert_not_in_import_dir(b"the_album", b"artifact.nfo")
         # `artifact2.file` will rename since the destination filename conflicts with `artifact.file`
         self.assert_in_import_dir(b"the_album", b"artifact2.file")
 


### PR DESCRIPTION
This introduces settings to look for and target "pairs" (files having the same name as a matching or "paired" media item/track). This can also target/include _only_ paired files, too.

Path formats can also be specifically set for these pairs, by `ext`.