### PR TITLE
Add tests for renaming illegal chars

### DIFF
--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -74,7 +74,7 @@ class CopyFileArtifactsFilename(CopyFileArtifactsTestCase):
 
         self._create_file(
             self.album_path,
-            b"CoolSName: Album&Tag.log",
+            b"Cool$Name: Album&Tag.log",
         )
         medium = self._create_medium(
             os.path.join(self.album_path, b"track_1.mp3"),
@@ -89,7 +89,7 @@ class CopyFileArtifactsFilename(CopyFileArtifactsTestCase):
             b"Tag Artist",
             b"Album_ Subtitle",
             beets.util.bytestring_path(
-                "Album_ Subtitle - CoolSName_ Album&Tag.log"
+                "Album_ Subtitle - Cool$Name_ Album&Tag.log"
             ),
         )
 

--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -25,12 +25,9 @@ class CopyFileArtifactsFilename(CopyFileArtifactsTestCase):
         config["copyfileartifacts"]["extensions"] = ".file"
 
     def test_import_dir_with_unicode_character_in_artifact_name_copy(self):
-        open(
-            os.path.join(
-                self.album_path, beets.util.bytestring_path("\xe4rtifact.file")
-            ),
-            "a",
-        ).close()
+        self._create_file(
+            self.album_path, beets.util.bytestring_path("\xe4rtifact.file")
+        )
         medium = self._create_medium(
             os.path.join(self.album_path, b"track_1.mp3"), self.rsrc_mp3
         )
@@ -47,12 +44,9 @@ class CopyFileArtifactsFilename(CopyFileArtifactsTestCase):
     def test_import_dir_with_unicode_character_in_artifact_name_move(self):
         config["import"]["move"] = True
 
-        open(
-            os.path.join(
-                self.album_path, beets.util.bytestring_path("\xe4rtifact.file")
-            ),
-            "a",
-        ).close()
+        self._create_file(
+            self.album_path, beets.util.bytestring_path("\xe4rtifact.file")
+        )
         medium = self._create_medium(
             os.path.join(self.album_path, b"track_1.mp3"), self.rsrc_mp3
         )
@@ -66,11 +60,44 @@ class CopyFileArtifactsFilename(CopyFileArtifactsTestCase):
             beets.util.bytestring_path("\xe4rtifact.file"),
         )
 
+    def test_import_with_illegal_character_in_artifact_name_obeys_beets(
+        self,
+    ):
+        config["import"]["move"] = True
+        config["copyfileartifacts"]["extensions"] = ".log"
+        config["paths"]["ext:.log"] = str("$albumpath/$album - $old_filename")
+
+        self.lib.path_formats[0] = (
+            "default",
+            os.path.join("$artist", "$album", "$album - $title"),
+        )
+
+        self._create_file(
+            self.album_path,
+            b"CoolSName: Album&Tag.log",
+        )
+        medium = self._create_medium(
+            os.path.join(self.album_path, b"track_1.mp3"),
+            self.rsrc_mp3,
+            album="Album: Subtitle",
+        )
+        self.import_media = [medium]
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(
+            b"Tag Artist",
+            b"Album_ Subtitle",
+            beets.util.bytestring_path(
+                "Album_ Subtitle - CoolSName_ Album&Tag.log"
+            ),
+        )
+
     def test_import_dir_with_illegal_character_in_album_name(self):
         config["paths"]["ext:file"] = str("$albumpath/$artist - $album")
 
         # Create import directory, illegal filename character used in the album name
-        open(os.path.join(self.album_path, b"artifact.file"), "a").close()
+        self._create_file(self.album_path, b"artifact.file")
         medium = self._create_medium(
             os.path.join(self.album_path, b"track_1.mp3"),
             self.rsrc_mp3,


### PR DESCRIPTION
This is an exploration of https://github.com/Holzhaus/beets-extrafiles/issues/7 which appears to not actually be a bug. Beets source replaces the following as part of sanitization (see [/beets/util/__init__.py#L623-L630](https://github.com/beetbox/beets/blob/4a9e7c1d3351d4b5ef67b01f924a3da70b64a74a/beets/util/__init__.py#L623-L630)):

```python
CHAR_REPLACE = [
    (re.compile(r'[\\/]'), '_'),  # / and \ -- forbidden everywhere.
    (re.compile(r'^\.'), '_'),  # Leading dot (hidden files on Unix).
    (re.compile(r'[\x00-\x1f]'), ''),  # Control characters.
    (re.compile(r'[<>:"\?\*\|]'), '_'),  # Windows "reserved characters".
    (re.compile(r'\.$'), '_'),  # Trailing dots.
    (re.compile(r'\s+$'), ''),  # Trailing whitespace.
]
```

Meaning, `_` is the actual correct replacement. Thus, tests have been added but nothing else should be actionable at this time.