### PR TITLE
Fix py3.6 CI issue & ignore py3.11 Win fails

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -12,10 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
+        continue-on-error: ${{ matrix.experimental }}
+        experimental: [false]
         include:
           - python-version: "3.6"
+            os: ubuntu-20.04
             tox-env: py36
           - python-version: "3.7"
             tox-env: py37
@@ -27,9 +30,9 @@ jobs:
             tox-env: py310
           - python-version: "3.11"
             tox-env: py311
-        exclude:
-          - os: windows-latest
-            python-version: "3.11"
+          - python-version: "3.11"
+            os: windows-latest
+            experimental: true
     env:
       TOXENV: ${{ matrix.tox-env }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,6 +18,9 @@ jobs:
           - python-version: "3.6"
             os: ubuntu-20.04
             tox-env: py36
+          - python-version: "3.6"
+            os: windows-latest
+            tox-env: py36
           - python-version: "3.7"
             tox-env: py37
           - python-version: "3.8"

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
-        experimental: [false]
         include:
           - python-version: "3.6"
             os: ubuntu-20.04
@@ -31,11 +30,10 @@ jobs:
             tox-env: py311
           - python-version: "3.11"
             os: windows-latest
-            experimental: true
     env:
       TOXENV: ${{ matrix.tox-env }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.os == 'windows-latest' && matrix.python-version == '3.11' }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
-        continue-on-error: ${{ matrix.experimental }}
         experimental: [false]
         include:
           - python-version: "3.6"
@@ -36,6 +35,7 @@ jobs:
     env:
       TOXENV: ${{ matrix.tox-env }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -31,8 +31,6 @@ jobs:
             tox-env: py310
           - python-version: "3.11"
             tox-env: py311
-          - python-version: "3.11"
-            os: windows-latest
     env:
       TOXENV: ${{ matrix.tox-env }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Fixes Ubuntu to 20.04 for Py3.6 and alters how Windows 11 & Py3.11 interact.